### PR TITLE
MQ 태그 치환 과정 중 버그 fix

### DIFF
--- a/js/chatassistx/plugins/dccon.js
+++ b/js/chatassistx/plugins/dccon.js
@@ -350,7 +350,7 @@
 			var message = args.message;
 
 			//마퀴태그 치환
-			message = message.replace(/\[mq( direction=([^\ ])*)?( behavior=[^\ ]*)?( loop=[^\ ]*)?( scrollamount=[0-9]*)?( scrolldelay=[0-9]*)?\](.*)\[\/mq\]/g, replaceMarquee);
+			message = message.replace(/\[mq( direction=[^\ ]*)?( behavior=[^\ ]*)?( loop=[^\ ]*)?( scrollamount=[0-9]*)?( scrolldelay=[0-9]*)?\](.*)\[\/mq\]/g, replaceMarquee);
 
 			if (window.ChatAssistX.config.allowEmoticon) {
 				//디시콘치환


### PR DESCRIPTION
MQ 태그 치환하지 않고 그대로 print되는 버그 fix

![MQ](https://user-images.githubusercontent.com/46076921/192138909-ac50e11a-7533-4cfa-bb58-75d6f125b167.png)
